### PR TITLE
Bugfix: Segmentation colors

### DIFF
--- a/Source/UnrealGT/Private/Generators/Image/GTSceneCaptureComponent2D.cpp
+++ b/Source/UnrealGT/Private/Generators/Image/GTSceneCaptureComponent2D.cpp
@@ -311,6 +311,7 @@ void UGTSceneCaptureComponent2D::SetupSegmentationPostProccess(
                     //{
                     if (FilterColorPair.Key.MatchesComponent(PrimitiveComponent))
                     {
+                        ComponentColor = FilterColorPair.Value;
                         // Reuse color if this filter already had a match with another component
                         if (ComponentFilterToColorID.Contains(FilterColorPair.Key))
                         {
@@ -324,7 +325,6 @@ void UGTSceneCaptureComponent2D::SetupSegmentationPostProccess(
                         }
                         bHasMatch = true;
                         ComponentFilterToColorID.Add(FilterColorPair.Key, ComponentColorID);
-                        ComponentColor = FilterColorPair.Value;
                     }
                 }
             }


### PR DESCRIPTION
This change fixes a bug in which the color to be used for a given segmentation key is set from a temporary local variable _before_ the local variable is updated to correspond to the correct value from `ComponentFilterToColor`, leading to incorrect segmentation colors in the final image.

I discovered the bug while running the UnrealGT plugin on UE5. I'm new to Unreal Engine development, and this is the first time I've used UnrealGT, so please excuse (and advise) if I've missed any important steps in the contribution process. In particular, are there any unit tests I can run to be sure my change doesn't break any other behaviors for UE5 or any other versions of UE?