### PR TITLE
Refactor: Extract a base class for Generator Triggers.

### DIFF
--- a/Source/UnrealGT/Private/Triggers/GTGeneratorTrigger.cpp
+++ b/Source/UnrealGT/Private/Triggers/GTGeneratorTrigger.cpp
@@ -1,0 +1,36 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "Triggers/GTGeneratorTrigger.h"
+
+#include <Engine/World.h>
+#include <TimerManager.h>
+
+#include "Generators/GTDataGeneratorComponent.h"
+
+// Sets default values for this component's properties
+UGTGeneratorTrigger::UGTGeneratorTrigger()
+{
+}
+
+void UGTGeneratorTrigger::Trigger()
+{
+    FDateTime TimeStamp = FDateTime::Now();
+    // TODO re-add trigger all option
+    // TODO so linkedimage generators in actor info are triggered before actor
+    // ifno segmentation
+    for (const FGTGeneratorReference& GeneratorReference : DataGenerators)
+    {
+        UGTDataGeneratorComponent* GeneratorComponent = GeneratorReference.GetComponent(GetOwner());
+        if (GeneratorComponent)
+        {
+            GeneratorComponent->GenerateData(TimeStamp);
+        }
+    }
+}
+
+
+// Called when the game starts
+void UGTGeneratorTrigger::BeginPlay()
+{
+    Super::BeginPlay();
+}

--- a/Source/UnrealGT/Private/Triggers/GTGeneratorTrigger.cpp
+++ b/Source/UnrealGT/Private/Triggers/GTGeneratorTrigger.cpp
@@ -15,9 +15,6 @@ UGTGeneratorTrigger::UGTGeneratorTrigger()
 void UGTGeneratorTrigger::Trigger()
 {
     FDateTime TimeStamp = FDateTime::Now();
-    // TODO re-add trigger all option
-    // TODO so linkedimage generators in actor info are triggered before actor
-    // ifno segmentation
     for (const FGTGeneratorReference& GeneratorReference : DataGenerators)
     {
         UGTDataGeneratorComponent* GeneratorComponent = GeneratorReference.GetComponent(GetOwner());

--- a/Source/UnrealGT/Private/Triggers/GTTimedGeneratorTrigger.cpp
+++ b/Source/UnrealGT/Private/Triggers/GTTimedGeneratorTrigger.cpp
@@ -19,7 +19,7 @@ void UGTTimedGeneratorTrigger::BeginPlay()
 {
     Super::BeginPlay();
 
-    if (FrameRate != 0.0)
+    if (FrameRate <= 0.F)
     {
         GetWorld()->GetTimerManager().SetTimer(
             TriggerTimerHandle, this, &UGTTimedGeneratorTrigger::Trigger, 1 / FrameRate, true);

--- a/Source/UnrealGT/Private/Triggers/GTTimedGeneratorTrigger.cpp
+++ b/Source/UnrealGT/Private/Triggers/GTTimedGeneratorTrigger.cpp
@@ -14,27 +14,14 @@ UGTTimedGeneratorTrigger::UGTTimedGeneratorTrigger()
 {
 }
 
-void UGTTimedGeneratorTrigger::Trigger()
-{
-    FDateTime TimeStamp = FDateTime::Now();
-    // TODO re-add trigger all option
-    // TODO so linkedimage generators in actor info are triggered before actor
-    // ifno segmentation
-    for (const FGTGeneratorReference& GeneratorReference : DataGenerators)
-    {
-        UGTDataGeneratorComponent* GeneratorComponent = GeneratorReference.GetComponent(GetOwner());
-        if (GeneratorComponent)
-        {
-            GeneratorComponent->GenerateData(TimeStamp);
-        }
-    }
-}
-
 // Called when the game starts
 void UGTTimedGeneratorTrigger::BeginPlay()
 {
     Super::BeginPlay();
 
-    GetWorld()->GetTimerManager().SetTimer(
-        TriggerTimerHandle, this, &UGTTimedGeneratorTrigger::Trigger, 1 / FrameRate, true);
+    if (FrameRate != 0.0)
+    {
+        GetWorld()->GetTimerManager().SetTimer(
+            TriggerTimerHandle, this, &UGTTimedGeneratorTrigger::Trigger, 1 / FrameRate, true);
+    }
 }

--- a/Source/UnrealGT/Public/Triggers/GTGeneratorTrigger.h
+++ b/Source/UnrealGT/Public/Triggers/GTGeneratorTrigger.h
@@ -1,0 +1,30 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "Components/ActorComponent.h"
+#include "CoreMinimal.h"
+
+#include "GTGeneratorReference.h"
+
+#include "GTGeneratorTrigger.generated.h"
+
+UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
+class UNREALGT_API UGTGeneratorTrigger : public UActorComponent {
+  GENERATED_BODY()
+
+public:
+  // Sets default values for this component's properties
+  UGTGeneratorTrigger();
+
+  UFUNCTION(BlueprintCallable, Category = Triggers)
+  virtual void Trigger();
+
+protected:
+  // Called when the game starts
+  virtual void BeginPlay() override;
+
+  UPROPERTY(EditAnywhere, Category = TriggerSettings, meta = (EditCondition = "!bTriggerAllGeneratorComponents"))
+  TArray<FGTGeneratorReference> DataGenerators;
+
+};

--- a/Source/UnrealGT/Public/Triggers/GTTimedGeneratorTrigger.h
+++ b/Source/UnrealGT/Public/Triggers/GTTimedGeneratorTrigger.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "Components/ActorComponent.h"
+#include "GTGeneratorTrigger.h"
 #include "CoreMinimal.h"
 
 #include "GTGeneratorReference.h"
@@ -10,15 +10,13 @@
 #include "GTTimedGeneratorTrigger.generated.h"
 
 UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
-class UNREALGT_API UGTTimedGeneratorTrigger : public UActorComponent {
+class UNREALGT_API UGTTimedGeneratorTrigger : public UGTGeneratorTrigger
+{
   GENERATED_BODY()
 
 public:
   // Sets default values for this component's properties
   UGTTimedGeneratorTrigger();
-
-public:
-  virtual void Trigger();
 
 protected:
   // Called when the game starts
@@ -31,10 +29,6 @@ private:
   UPROPERTY(EditAnywhere, Category = TriggerSettings,
             meta = (EditCondition = "!bTriggerEveryFrame", ClampMin = 0))
   float FrameRate;
-
-  UPROPERTY(EditAnywhere, Category = TriggerSettings,
-            meta = (EditCondition = "!bTriggerAllGeneratorComponents"))
-  TArray<FGTGeneratorReference> DataGenerators;
 
   FTimerHandle TriggerTimerHandle;
 };

--- a/UnrealGT.uplugin
+++ b/UnrealGT.uplugin
@@ -16,7 +16,7 @@
 	"Modules": [
 		{
 			"Name": "UnrealGT",
-			"Type": "Editor",
+			"Type": "Runtime",
 			"LoadingPhase": "Default"
 		}
 	]


### PR DESCRIPTION
Refactors the GTTimedGeneratorTrigger to derive from a base class GTGeneratorTrigger. This allows a user to trigger based on other events in a blueprint. 

For example, here I've used it to generate ground truth when a key is pressed.

![TriggerOnKey](https://user-images.githubusercontent.com/104098342/178909249-55275248-5c3e-4271-a536-0a8a0f8cdceb.PNG)

Also in this PR:
* A guard for a possible divide by zero.
* Changes in UnrealGT.uplugin to make the plugin a Runtime Module so that it's possible to expose the Trigger function to blueprints.

**Note**: I haven't tested this change for compatibility with all other editor features, or versions of Unreal Engine less than 5.0.3. Please advise if there's a recommended testing workflow.