### PR TITLE
Support dynamically added segmentation targets

### DIFF
--- a/Source/UnrealGT/Private/GTRandomColorGenerator.cpp
+++ b/Source/UnrealGT/Private/GTRandomColorGenerator.cpp
@@ -1,0 +1,45 @@
+#include "GTRandomColorGenerator.h"
+
+#include "Math/Color.h"
+
+TArray<int> MakeSequentialIndexArray(const int FirstIndex, const int LastIndex)
+{
+    TArray<int> arr;
+    arr.Reserve(255);
+    for (auto i = FirstIndex; i <= LastIndex; i++)
+        arr.Emplace(i);
+    return arr;
+}
+
+void ShuffleArray(TArray<int>& Arr)
+{
+    for (int i = 0; i < Arr.Num(); ++i)
+    {
+        int Index = FMath::RandRange(i, Arr.Num() - 1);
+        if (i != Index)
+        {
+            Arr.Swap(i, Index);
+        }
+    }
+}
+
+TArray<int> MakeShuffledIntArray(const int LowestIndex, const int HighestIndex)
+{
+    TArray<int> IDs = MakeSequentialIndexArray(LowestIndex, HighestIndex);
+    ShuffleArray(IDs);
+    return IDs;
+}
+
+GTRandomColorGenerator::GTRandomColorGenerator(int MaxHue)
+    : RandomHues(MakeShuffledIntArray(1, MaxHue))
+{
+}
+
+FColor GTRandomColorGenerator::GetNextRandomColor()
+{
+    const auto Hue = RandomHues[CurrentIndex];
+    CurrentIndex = (CurrentIndex + 1) % RandomHues.Num();
+    return FLinearColor((float)Hue / (float)255 * 360.f, 0.99f, 0.99f)
+        .HSVToLinearRGB()
+        .ToFColor(false);
+}

--- a/Source/UnrealGT/Private/GTRandomColorGenerator.cpp
+++ b/Source/UnrealGT/Private/GTRandomColorGenerator.cpp
@@ -2,40 +2,43 @@
 
 #include "Math/Color.h"
 
-TArray<int> MakeSequentialIndexArray(const int FirstIndex, const int LastIndex)
+namespace
 {
-    TArray<int> arr;
-    arr.Reserve(255);
-    for (auto i = FirstIndex; i <= LastIndex; i++)
-        arr.Emplace(i);
-    return arr;
-}
-
-void ShuffleArray(TArray<int>& Arr)
-{
-    for (int i = 0; i < Arr.Num(); ++i)
+    TArray<int> MakeSequentialIndexArray(const int FirstIndex, const int LastIndex)
     {
-        int Index = FMath::RandRange(i, Arr.Num() - 1);
-        if (i != Index)
+        TArray<int> arr;
+        arr.Reserve(LastIndex - FirstIndex + 1);
+        for (auto i = FirstIndex; i <= LastIndex; i++)
+            arr.Emplace(i);
+        return arr;
+    }
+
+    void ShuffleArray(TArray<int>& Arr)
+    {
+        for (int i = 0; i < Arr.Num(); ++i)
         {
-            Arr.Swap(i, Index);
+            int Index = FMath::RandRange(i, Arr.Num() - 1);
+            if (i != Index)
+            {
+                Arr.Swap(i, Index);
+            }
         }
+    }
+
+    TArray<int> MakeShuffledIntArray(const int LowestIndex, const int HighestIndex)
+    {
+        TArray<int> IDs = MakeSequentialIndexArray(LowestIndex, HighestIndex);
+        ShuffleArray(IDs);
+        return IDs;
     }
 }
 
-TArray<int> MakeShuffledIntArray(const int LowestIndex, const int HighestIndex)
-{
-    TArray<int> IDs = MakeSequentialIndexArray(LowestIndex, HighestIndex);
-    ShuffleArray(IDs);
-    return IDs;
-}
-
-GTRandomColorGenerator::GTRandomColorGenerator(int MaxHue)
+FGTRandomColorGenerator::FGTRandomColorGenerator(int MaxHue)
     : RandomHues(MakeShuffledIntArray(1, MaxHue))
 {
 }
 
-FColor GTRandomColorGenerator::GetNextRandomColor()
+FColor FGTRandomColorGenerator::GetNextRandomColor()
 {
     const auto Hue = RandomHues[CurrentIndex];
     CurrentIndex = (CurrentIndex + 1) % RandomHues.Num();

--- a/Source/UnrealGT/Private/Generators/Image/GTSceneCaptureComponent2D.cpp
+++ b/Source/UnrealGT/Private/Generators/Image/GTSceneCaptureComponent2D.cpp
@@ -8,7 +8,10 @@
 #include <Engine/TextureRenderTarget2D.h>
 #include <Materials/MaterialInstanceDynamic.h>
 
-const FColor KBlack = FColor(0, 0, 0, 255);
+namespace
+{
+    constexpr int MaxColorIndex = 255;
+}
 
 UGTSceneCaptureComponent2D::UGTSceneCaptureComponent2D()
     : Super()
@@ -230,10 +233,10 @@ FColor AssignRandomColor(
     UPrimitiveComponent* PrimitiveComponent,
     bool bUseFilterForColorEachComponentDifferent,
     const FGTObjectFilter& ColorEachComponentDifferentFilter,
-    GTRandomColorGenerator& RandomColorGenerator)
+    FGTRandomColorGenerator& RandomColorGenerator)
 {
     if (!bUseFilterForColorEachComponentDifferent) return RandomColorGenerator.GetNextRandomColor();
-    if (!ColorEachComponentDifferentFilter.MatchesComponent(PrimitiveComponent)) return KBlack;
+    if (!ColorEachComponentDifferentFilter.MatchesComponent(PrimitiveComponent)) return FColor::Black;
     return RandomColorGenerator.GetNextRandomColor();
 }
 
@@ -245,7 +248,7 @@ FColor DetermineColor(
     {
         if (FilterColorPair.Key.MatchesComponent(PrimitiveComponent)) return FilterColorPair.Value;
     }
-    return KBlack;
+    return FColor::Black;
 }
 
 void UGTSceneCaptureComponent2D::RegisterForSegmentation(
@@ -255,7 +258,7 @@ void UGTSceneCaptureComponent2D::RegisterForSegmentation(
     bool bUseFilterForColorEachComponentDifferent,
     const FGTObjectFilter& ColorEachComponentDifferentFilter)
 {
-    if (NextAssignableColorArrayIndex > KMaxColorIndex)
+    if (NextAssignableColorArrayIndex > MaxColorIndex)
     {
         // TODO(tha-carta): Define a custom logging category for UnrealGT.
         UE_LOG(LogTemp, Warning, TEXT("Reached the maximum number of segmentation colors."))
@@ -279,7 +282,7 @@ void UGTSceneCaptureComponent2D::RegisterForSegmentation(
     }
     PrimitiveComponent->SetRenderCustomDepth(true);
     PrimitiveComponent->SetCustomDepthStencilValue(ColorIndexCache[PrimColor]);
-    if (PrimColor != KBlack)
+    if (PrimColor != FColor::Black)
         ComponentToColor.Add(PrimitiveComponent, ColorArray[ColorIndexCache[PrimColor]]);
 }
 
@@ -290,8 +293,8 @@ void UGTSceneCaptureComponent2D::SetupSegmentationPostProccess(
     bool bUseFilterForColorEachComponentDifferent,
     const FGTObjectFilter& ColorEachComponentDifferentFilter)
 {
-    ColorArray.Init(KBlack, KMaxColorIndex + 1);  // Prefill with black.
-    ColorIndexCache.Reserve(KMaxColorIndex + 1);
+    ColorArray.Init(FColor::Black, MaxColorIndex + 1);  // Prefill with black.
+    ColorIndexCache.Reserve(MaxColorIndex + 1);
 
     for (TObjectIterator<UPrimitiveComponent> Itr; Itr; ++Itr)
     {

--- a/Source/UnrealGT/Private/Generators/Image/GTSceneCaptureComponent2D.cpp
+++ b/Source/UnrealGT/Private/Generators/Image/GTSceneCaptureComponent2D.cpp
@@ -8,6 +8,8 @@
 #include <Engine/TextureRenderTarget2D.h>
 #include <Materials/MaterialInstanceDynamic.h>
 
+const FColor KBlack = FColor(0, 0, 0, 255);
+
 UGTSceneCaptureComponent2D::UGTSceneCaptureComponent2D()
     : Super()
     , bColorAsFloat(false)
@@ -223,6 +225,29 @@ UTexture2D* UGTSceneCaptureComponent2D::TextureFromImage(const FGTImage& Image, 
     return OutTexture;
 }
 
+
+FColor AssignRandomColor(
+    UPrimitiveComponent* PrimitiveComponent,
+    bool bUseFilterForColorEachComponentDifferent,
+    const FGTObjectFilter& ColorEachComponentDifferentFilter,
+    GTRandomColorGenerator& RandomColorGenerator)
+{
+    if (!bUseFilterForColorEachComponentDifferent) return RandomColorGenerator.GetNextRandomColor();
+    if (!ColorEachComponentDifferentFilter.MatchesComponent(PrimitiveComponent)) return KBlack;
+    return RandomColorGenerator.GetNextRandomColor();
+}
+
+FColor DetermineColor(
+    UPrimitiveComponent* PrimitiveComponent,
+    const TMap<FGTObjectFilter, FColor>& ComponentFilterToColor)
+{
+    for (const auto& FilterColorPair : ComponentFilterToColor)
+    {
+        if (FilterColorPair.Key.MatchesComponent(PrimitiveComponent)) return FilterColorPair.Value;
+    }
+    return KBlack;
+}
+
 void UGTSceneCaptureComponent2D::SetupSegmentationPostProccess(
     const TMap<FGTObjectFilter, FColor>& ComponentFilterToColor,
     bool bShouldApplyCloseMorph,
@@ -230,126 +255,48 @@ void UGTSceneCaptureComponent2D::SetupSegmentationPostProccess(
     bool bUseFilterForColorEachComponentDifferent,
     const FGTObjectFilter& ColorEachComponentDifferentFilter)
 {
-    int ArraySize = 256;
-    ColorArray.Empty(ArraySize);
-    ColorArray.Reserve(ArraySize);
-    // First item is black
-    ColorArray.Push(FColor(0, 0, 0, 255));
+    const int KMaxColorIdx = 255;
+    ColorArray.Init(KBlack, KMaxColorIdx + 1); // Prefill with black.
+    int NextColorIdx = 0;
 
-    TMap<FGTObjectFilter, int> ComponentFilterToColorID;
-    TMap<AActor*, int> ActorToColorID;
-
-    auto ColorID = 1;
-
-    // Create Random colorId array for bColorEachComponentDifferent
-    // This will allow consistent colors if the tracked component count exceeds 255
-    TArray<int> RandomColorIDs;
-    RandomColorIDs.Reserve(255);
-    for (auto I = 0; I < 255; I++)
-    {
-        RandomColorIDs.Push(I + 1);
-    }
-
-    int32 LastIndex = RandomColorIDs.Num() - 1;
-    for (int32 i = 0; i <= LastIndex; ++i)
-    {
-        int32 Index = FMath::RandRange(i, LastIndex);
-        if (i != Index)
-        {
-            RandomColorIDs.Swap(i, Index);
-        }
-    }
-
+    // Hold onto the indices of already assigned colors so we can give the 
+    // same ColorArray index to objects that should have the same color.
+    TMap<FColor, int> ColorToIndex;
+    ColorToIndex.Reserve(KMaxColorIdx + 1);
+    
     for (TObjectIterator<UPrimitiveComponent> Itr; Itr; ++Itr)
     {
-        UPrimitiveComponent* PrimitiveComponent = *Itr;
-
-        if (PrimitiveComponent->GetWorld() == GetWorld())
+        if (NextColorIdx > KMaxColorIdx)
         {
-            auto bHasMatch = false;
-            FColor ComponentColor;
-            auto ComponentColorID = ColorID;
-
-            if (bColorEachComponentDifferent)
-            {
-                if (!bUseFilterForColorEachComponentDifferent ||
-                    (bUseFilterForColorEachComponentDifferent &&
-                     ColorEachComponentDifferentFilter.MatchesComponent(PrimitiveComponent)))
-                {
-                    bHasMatch = true;
-                    // Cylce through colors once we hit 255 limit
-                    if (ColorID <= 255)
-                    {
-                        auto Hue = RandomColorIDs[ComponentColorID - 1];
-
-                        ComponentColor = FLinearColor((float)Hue / (float)255 * 360.f, 0.99f, 0.99f)
-                                             .HSVToLinearRGB()
-                                             .ToFColor(false);
-
-                        ColorArray.Push(ComponentColor);
-                        ColorID++;
-                    }
-                    else
-                    {
-                        ComponentColorID = (ColorID - 1) % 255 + 1;
-                        ColorID++;
-                    }
-                }
-            }
-            else
-            {
-                for (const auto& FilterColorPair : ComponentFilterToColor)
-                {
-                    // TODO readd  to make all components of actor same color
-                    // and add option
-                    // if (PrimitiveComponent->GetOwner() &&
-                    // ActorToColorID.Contains(PrimitiveComponent->GetOwner()))
-                    //{
-                    //    ComponentColorID = ActorToColorID[PrimitiveComponent->GetOwner()];
-                    //}
-                    // else
-                    //{
-                    if (FilterColorPair.Key.MatchesComponent(PrimitiveComponent))
-                    {
-                        ComponentColor = FilterColorPair.Value;
-                        // Reuse color if this filter already had a match with another component
-                        if (ComponentFilterToColorID.Contains(FilterColorPair.Key))
-                        {
-                            ComponentColorID = ComponentFilterToColorID[FilterColorPair.Key];
-                        }
-                        else
-                        {
-                            ComponentColorID = ColorID;
-                            ColorArray.Push(ComponentColor);
-                            ColorID++;
-                        }
-                        bHasMatch = true;
-                        ComponentFilterToColorID.Add(FilterColorPair.Key, ComponentColorID);
-                    }
-                }
-            }
-
-            if (bHasMatch)
-            {
-                PrimitiveComponent->SetRenderCustomDepth(true);
-                PrimitiveComponent->SetCustomDepthStencilValue(ComponentColorID);
-
-                ComponentToColor.Add(PrimitiveComponent, ColorArray[ComponentColorID]);
-            }
-            else
-            {
-                PrimitiveComponent->SetRenderCustomDepth(true);
-                PrimitiveComponent->SetCustomDepthStencilValue(0);
-            }
+            // TODO(tha-carta): Define a custom logging category for UnrealGT.
+            UE_LOG(LogTemp, Warning, TEXT("Reached the maximum number of segmentation colors."))
+            break;
         }
-    }
 
-    for (auto I = ColorID; I < ArraySize; I++)
-    {
-        ColorArray.Add(FColor::Black);
-    }
+        UPrimitiveComponent* PrimitiveComponent = *Itr;
+        if (PrimitiveComponent->GetWorld() != GetWorld()) continue;
 
-    const auto TextureSize = ArraySize * 3;
+        const auto PrimColor =
+            bColorEachComponentDifferent
+                                   ? AssignRandomColor(
+                                         PrimitiveComponent,
+                                         bUseFilterForColorEachComponentDifferent,
+                                         ColorEachComponentDifferentFilter,
+                                         RandomColorGenerator)
+                                   : DetermineColor(PrimitiveComponent, ComponentFilterToColor);
+        if (!ColorToIndex.Contains(PrimColor))
+        {
+            ColorArray[NextColorIdx] = PrimColor;
+            ColorToIndex.Emplace(PrimColor, NextColorIdx);
+            NextColorIdx++;
+        }
+        PrimitiveComponent->SetRenderCustomDepth(true);
+        PrimitiveComponent->SetCustomDepthStencilValue(ColorToIndex[PrimColor]);
+        // TODO(tha-carta): Is this used anywhere?
+        if (PrimColor != KBlack) ComponentToColor.Add(PrimitiveComponent, ColorArray[ColorToIndex[PrimColor]]);
+    }
+    
+    const auto TextureSize = ColorArray.Num() * 3;
     TArray<FColor> TextureColors;
     TextureColors.Reserve(TextureSize);
     for (auto Color : ColorArray)

--- a/Source/UnrealGT/Public/GTRandomColorGenerator.h
+++ b/Source/UnrealGT/Public/GTRandomColorGenerator.h
@@ -2,10 +2,10 @@
 
 #include "CoreMinimal.h"
 
-struct UNREALGT_API GTRandomColorGenerator
+struct UNREALGT_API FGTRandomColorGenerator
 {
 public:
-    GTRandomColorGenerator(int MaxHue = 255);
+    FGTRandomColorGenerator(int MaxHue = 255);
     FColor GetNextRandomColor();
 
 private:

--- a/Source/UnrealGT/Public/GTRandomColorGenerator.h
+++ b/Source/UnrealGT/Public/GTRandomColorGenerator.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+struct UNREALGT_API GTRandomColorGenerator
+{
+public:
+    GTRandomColorGenerator(int MaxHue = 255);
+    FColor GetNextRandomColor();
+
+private:
+    const TArray<int> RandomHues;
+    int CurrentIndex = 0;
+};

--- a/Source/UnrealGT/Public/Generators/Image/GTSceneCaptureComponent2D.h
+++ b/Source/UnrealGT/Public/Generators/Image/GTSceneCaptureComponent2D.h
@@ -64,7 +64,16 @@ public:
 
     void SetupSegmentationPostProccess(
         const TArray<FGTObjectFilter>& ComponentFilters,
-        bool bShouldApplyCloseMorph = false);
+        bool bColorEachComponentDifferent = false);
+
+    void SetupSegmentationBlendable(bool bShouldApplyCloseMorph);
+
+    void RegisterForSegmentation(
+        UPrimitiveComponent *PrimitiveComponent,
+        const TMap<FGTObjectFilter, FColor>& ComponentFilterToColor,
+        bool bColorEachComponentDifferent = false,
+        bool bUseFilterForColorEachComponentDifferent = false,
+        const FGTObjectFilter& ColorEachComponentDifferentFilter = FGTObjectFilter());
 
     TArray<FColor> GetSegmentColorsUsedForActor(AActor* Actor);
 
@@ -80,7 +89,10 @@ protected:
     void BeginPlay() override;
 
 private:
+    const int KMaxColorIndex = 255;
     TArray<FColor> ColorArray;
+    int NextAssignableColorArrayIndex = 0;
+    TMap<FColor, int> ColorIndexCache;
     GTRandomColorGenerator RandomColorGenerator;
 
     // TODO remove after debuging or write getter

--- a/Source/UnrealGT/Public/Generators/Image/GTSceneCaptureComponent2D.h
+++ b/Source/UnrealGT/Public/Generators/Image/GTSceneCaptureComponent2D.h
@@ -9,6 +9,7 @@
 
 #include "GTImage.h"
 #include "GTObjectFilter.h"
+#include "GTRandomColorGenerator.h"
 
 #include "GTSceneCaptureComponent2D.generated.h"
 
@@ -16,7 +17,7 @@ class UTexture2D;
 class UMaterial;
 class UMaterialInstanceDynamic;
 class UGTImageGeneratorBase;
-
+class RandomColorGenerator;
 /**
  *
  */
@@ -80,6 +81,7 @@ protected:
 
 private:
     TArray<FColor> ColorArray;
+    GTRandomColorGenerator RandomColorGenerator;
 
     // TODO remove after debuging or write getter
 public:

--- a/Source/UnrealGT/Public/Generators/Image/GTSceneCaptureComponent2D.h
+++ b/Source/UnrealGT/Public/Generators/Image/GTSceneCaptureComponent2D.h
@@ -17,7 +17,6 @@ class UTexture2D;
 class UMaterial;
 class UMaterialInstanceDynamic;
 class UGTImageGeneratorBase;
-class RandomColorGenerator;
 /**
  *
  */
@@ -89,11 +88,10 @@ protected:
     void BeginPlay() override;
 
 private:
-    const int KMaxColorIndex = 255;
     TArray<FColor> ColorArray;
     int NextAssignableColorArrayIndex = 0;
     TMap<FColor, int> ColorIndexCache;
-    GTRandomColorGenerator RandomColorGenerator;
+    FGTRandomColorGenerator RandomColorGenerator;
 
     // TODO remove after debuging or write getter
 public:

--- a/Source/UnrealGT/Public/Generators/Image/GTSegmentationGeneratorComponent.h
+++ b/Source/UnrealGT/Public/Generators/Image/GTSegmentationGeneratorComponent.h
@@ -33,6 +33,11 @@ class UNREALGT_API UGTSegmentationGeneratorComponent : public UGTImageGeneratorB
 public:
     UGTSegmentationGeneratorComponent();
 
+    UFUNCTION(BlueprintCallable, Category = UnrealGTSegmentation)
+    void RegisterForSegmentation(UPrimitiveComponent* PrimitiveComponent);
+
+    virtual void GenerateData(const FDateTime& TimeStamp) override;
+
 protected:
     FString GenerateSegmentationInfoJSON() const;
 
@@ -86,4 +91,5 @@ private:
     FGTObjectFilter ColorEachComponentDifferentFilter;
 
     FString DebugComponentToColorString;
+    TArray<UPrimitiveComponent*> WaitingToBeRegistered;
 };


### PR DESCRIPTION
This change is a substantial refactor of the code that sets up the segmentation blendable in `GTSceneCaptureComponent2D`. Before this change, the blendable was called only once, on `BeginPlay`. As a result, any object spawned during gameplay would not be visible in segmentation outputs. 

This change decomposes the monolithic `SetupSegmentationPostProccess` function into smaller helper functions and classes for easier maintenance and reduced complexity.

The functional change is the addition of a `RegisterForSegmentation` callable in the `GTSegmentationGeneratorComponent` so that new targets can be dynamically added to segmentation. By making this an opt-in feature (the function needs to be called on the spawned primitive), we've avoided making this a breaking change for any legacy code that assumes that newly spawned actors will not be present in segmentation outputs.

As before, please note that this change is only tested on Unreal Engine 5.0. I'd recommend establishing a suite of unit tests or some recommended testing protocol when possible.